### PR TITLE
Should be toUpperCase

### DIFF
--- a/mappings/src/main/java/de/themoep/idconverter/IdMappings.java
+++ b/mappings/src/main/java/de/themoep/idconverter/IdMappings.java
@@ -875,7 +875,7 @@ public class IdMappings {
     }
     
     public static Mapping getByFlatteningType(String flatteningType) {
-        return BY_FLATTENING_NAME.get(flatteningType.toLowerCase());
+        return BY_FLATTENING_NAME.get(flatteningType.toUpperCase());
     }
     
     public static class Mapping {


### PR DESCRIPTION
The flatteningType is put into Mapping as uppercase but the getByFlatteningType sets to lower case, resulting in the method not working.